### PR TITLE
test(worker): prevenir reintrodução do fluxo legado

### DIFF
--- a/services/worker/test/legacy-flow-cleanup.spec.ts
+++ b/services/worker/test/legacy-flow-cleanup.spec.ts
@@ -26,6 +26,9 @@ describe('Worker legacy flow cleanup', () => {
     const mainSource = readFileSync(mainFilePath, 'utf8');
 
     expect(mainSource).toContain("import { WorkerModule } from './worker.module';");
+    expect(mainSource).toMatch(
+      /NestFactory\.createMicroservice(?:<[^>]+>)?\(\s*WorkerModule\b/
+    );
     expect(mainSource).not.toContain('AppModule');
   });
 });

--- a/services/worker/test/legacy-flow-cleanup.spec.ts
+++ b/services/worker/test/legacy-flow-cleanup.spec.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Worker legacy flow cleanup', () => {
+  const workerSrcDir = path.resolve(__dirname, '..', 'src');
+  const legacyAppModulePath = path.join(workerSrcDir, 'app.module.ts');
+  const legacyConsumerPath = path.join(
+    workerSrcDir,
+    'modules',
+    'billing',
+    'infrastructure',
+    'consumers',
+    'billing.consumer.ts'
+  );
+  const mainFilePath = path.join(workerSrcDir, 'main.ts');
+
+  it('does not keep legacy AppModule bootstrap path', () => {
+    expect(existsSync(legacyAppModulePath)).toBe(false);
+  });
+
+  it('does not keep legacy billing consumer path', () => {
+    expect(existsSync(legacyConsumerPath)).toBe(false);
+  });
+
+  it('bootstraps WorkerModule in worker main entrypoint', () => {
+    const mainSource = readFileSync(mainFilePath, 'utf8');
+
+    expect(mainSource).toContain("import { WorkerModule } from './worker.module';");
+    expect(mainSource).not.toContain('AppModule');
+  });
+});


### PR DESCRIPTION
## Contexto
Executa o follow-up da issue #4 para prevenir regressão arquitetural no worker após remoção do fluxo legado.

## O que foi feito
- Adicionado teste de regressão garantindo ausência dos caminhos legados no worker:
  - `services/worker/src/app.module.ts`
  - `services/worker/src/modules/billing/infrastructure/consumers/billing.consumer.ts`
- Validado por teste que o bootstrap ativo do worker permanece no `WorkerModule` (sem `AppModule`).

## 🧪 BDD
- **Given** o worker sem fluxo legado ativo
- **When** alguém tentar reintroduzir `app.module.ts` legado ou consumer legado fora do `WorkerModule`
- **Then** o teste de regressão falha, protegendo a arquitetura atual

## 🔥 Tipo de Release
- [x] Patch
- [ ] Minor
- [ ] Major

## Checklist
- [x] Teste de regressão adicionado para fluxo legado
- [x] `npm run typecheck` OK
- [x] `npm run build` OK
- [x] `npm test` OK
- [x] `npm test -- --coverage` OK

Closes #4