### PR TITLE
fix: serializar ensureConnection no publisher RMQ

### DIFF
--- a/services/api/src/modules/billing/infrastructure/messaging/rabbitmq-billing.publisher.ts
+++ b/services/api/src/modules/billing/infrastructure/messaging/rabbitmq-billing.publisher.ts
@@ -32,6 +32,7 @@ export class RabbitMqBillingPublisher
   });
   private connection?: ChannelModel;
   private channel?: Channel;
+  private connectionInFlight?: Promise<Channel>;
 
   private readonly topology = resolveRabbitMqTopology();
 
@@ -49,13 +50,35 @@ export class RabbitMqBillingPublisher
       return this.channel;
     }
 
-    this.connection = await connect(this.topology.url);
-    const channel = await this.connection.createChannel();
-    this.channel = channel;
+    if (!this.connectionInFlight) {
+      this.connectionInFlight = this.connectAndDeclareTopology()
+        .catch(error => {
+          this.channel = undefined;
+          this.connection = undefined;
+          throw error;
+        })
+        .finally(() => {
+          this.connectionInFlight = undefined;
+        });
+    }
 
-    await declareRabbitMqTopology(channel, this.topology);
+    return this.connectionInFlight;
+  }
 
-    return channel;
+  private async connectAndDeclareTopology(): Promise<Channel> {
+    const connection = await connect(this.topology.url);
+    this.connection = connection;
+
+    try {
+      const channel = await connection.createChannel();
+      await declareRabbitMqTopology(channel, this.topology);
+      this.channel = channel;
+      return channel;
+    } catch (error) {
+      await connection.close().catch(() => undefined);
+      this.connection = undefined;
+      throw error;
+    }
   }
 
   async publish(message: BillingJobMessage): Promise<void> {

--- a/services/api/test/rabbitmq-billing.publisher.spec.ts
+++ b/services/api/test/rabbitmq-billing.publisher.spec.ts
@@ -110,4 +110,36 @@ describe('RabbitMqBillingPublisher', () => {
       'billing.jobs.custom.dlq.route'
     );
   });
+
+  it('serializes connection bootstrap when publish runs concurrently', async () => {
+    const delayedConnection = {
+      createChannel: jest.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 20));
+        return channel;
+      }),
+      close: jest.fn().mockResolvedValue(undefined)
+    } as unknown as ChannelModel;
+    connectMock.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      return delayedConnection;
+    });
+
+    const publisher = new RabbitMqBillingPublisher();
+    const baseMessage = {
+      tenantId: 'tenant-a',
+      customerId: 'customer-1',
+      amount: 100,
+      issuedAt: '2026-03-01T00:00:00.000Z'
+    };
+
+    await Promise.all([
+      publisher.publish({ ...baseMessage, jobId: 'job-1' }),
+      publisher.publish({ ...baseMessage, jobId: 'job-2' }),
+      publisher.publish({ ...baseMessage, jobId: 'job-3' })
+    ]);
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(delayedConnection.createChannel).toHaveBeenCalledTimes(1);
+    expect(channel.publish).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
Closes #7

## 📌 Contexto
Chamadas concorrentes de `publish()` podiam disparar múltiplos `connect/createChannel` no publisher RabbitMQ da API, gerando risco de race e instabilidade sob carga.

## ✅ O que foi feito
- serialização do bootstrap de conexão com promise compartilhada (`connectionInFlight`) em `ensureConnection`
- extração da inicialização para `connectAndDeclareTopology`
- reset seguro de estado em falha de conexão/topologia para permitir retry posterior
- teste concorrente cobrindo `Promise.all` com múltiplos `publish()` simultâneos e garantindo uma única conexão/canal

## 🧪 BDD
**Cenário:** Publicações concorrentes não abrem múltiplas conexões
**Dado** uma instância do `RabbitMqBillingPublisher` sem conexão inicial
**Quando** três chamadas de `publish()` são executadas em paralelo
**Então** apenas uma conexão AMQP é criada
**E** apenas um channel é criado
**E** todas as mensagens são publicadas com sucesso

## 🔥 Tipo de Release
- [x] `patch` (correção de concorrência sem mudança de contrato)

## Checklist
- [x] Testes adicionados/atualizados
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`
- [x] Sem impacto no contrato multi-tenant

## Evidências locais
- Typecheck: passou
- Build: passou
- Testes: 62/62 passou
- Coverage global: statements 84.27%, branches 78.18%, functions 79.68%, lines 83.63%
