### PR TITLE
feat: padronizar logging estruturado na API e Worker

### DIFF
--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -4,10 +4,12 @@ import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
 import { startOpenTelemetry } from '../../shared/observability/open-telemetry';
+import { writeStructuredLog } from '../../shared/observability/structured-logger';
 import { AppModule } from './app.module';
 import { loadJwtRuntimeConfig } from './infrastructure/auth/jwt-config';
 
 async function bootstrap(): Promise<void> {
+  const logger = new Logger('API');
   const telemetry = startOpenTelemetry({
     serviceName: 'platform-api',
     defaultMetricsPort: 9464
@@ -18,11 +20,18 @@ async function bootstrap(): Promise<void> {
   const port = Number(process.env.PORT ?? process.env.API_PORT ?? 3000);
 
   await app.listen(port);
-  Logger.log(`API started on port ${port}`, 'API');
+  writeStructuredLog(logger, 'log', {
+    service: 'platform-api',
+    event: 'api.bootstrap.listen',
+    metadata: { port }
+  });
 
   const shutdownTelemetry = async (): Promise<void> => {
     await telemetry.shutdown();
-    Logger.log('OpenTelemetry SDK stopped', 'API');
+    writeStructuredLog(logger, 'log', {
+      service: 'platform-api',
+      event: 'api.telemetry.shutdown'
+    });
   };
 
   process.once('SIGINT', () => {
@@ -33,4 +42,12 @@ async function bootstrap(): Promise<void> {
   });
 }
 
-bootstrap();
+void bootstrap().catch(error => {
+  const logger = new Logger('API');
+  writeStructuredLog(logger, 'error', {
+    service: 'platform-api',
+    event: 'api.bootstrap.error',
+    error
+  });
+  process.exit(1);
+});

--- a/services/api/src/modules/billing/infrastructure/messaging/rabbitmq-billing.publisher.ts
+++ b/services/api/src/modules/billing/infrastructure/messaging/rabbitmq-billing.publisher.ts
@@ -8,6 +8,7 @@ import {
 import { Channel, ChannelModel, connect } from 'amqplib';
 import { createNestRmqEventEnvelope } from '../../../../../../shared/contracts/billing-job.contract';
 import { injectTraceContextToHeaders } from '../../../../../../shared/observability/rmq-trace-context';
+import { writeStructuredLog } from '../../../../../../shared/observability/structured-logger';
 import {
   declareRabbitMqTopology,
   resolveRabbitMqTopology
@@ -40,8 +41,14 @@ export class RabbitMqBillingPublisher
     try {
       await this.ensureConnection();
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
-      this.logger.warn(`RabbitMQ unavailable on startup (${reason}). Publisher will retry lazily.`);
+      writeStructuredLog(this.logger, 'warn', {
+        service: 'platform-api',
+        event: 'api.rabbitmq.publisher.startup_unavailable',
+        error,
+        metadata: {
+          retryMode: 'lazy'
+        }
+      });
     }
   }
 

--- a/services/shared/observability/structured-logger.spec.ts
+++ b/services/shared/observability/structured-logger.spec.ts
@@ -72,4 +72,39 @@ describe('writeStructuredLog', () => {
     expect(error.message).toBe('RabbitMQ unavailable');
     expect(typeof error.stack).toBe('string');
   });
+
+  it('preserves falsy primitive error values', () => {
+    writeStructuredLog(logger, 'error', {
+      service: 'platform-worker',
+      event: 'worker.failure.empty',
+      error: ''
+    });
+    writeStructuredLog(logger, 'error', {
+      service: 'platform-worker',
+      event: 'worker.failure.zero',
+      error: 0
+    });
+    writeStructuredLog(logger, 'error', {
+      service: 'platform-worker',
+      event: 'worker.failure.false',
+      error: false
+    });
+
+    const first = JSON.parse((logger.error as jest.Mock).mock.calls[0][0] as string) as Record<
+      string,
+      unknown
+    >;
+    const second = JSON.parse((logger.error as jest.Mock).mock.calls[1][0] as string) as Record<
+      string,
+      unknown
+    >;
+    const third = JSON.parse((logger.error as jest.Mock).mock.calls[2][0] as string) as Record<
+      string,
+      unknown
+    >;
+
+    expect(first.error).toBe('');
+    expect(second.error).toBe(0);
+    expect(third.error).toBe(false);
+  });
 });

--- a/services/shared/observability/structured-logger.spec.ts
+++ b/services/shared/observability/structured-logger.spec.ts
@@ -1,0 +1,75 @@
+import type { LoggerService } from '@nestjs/common';
+
+import { writeStructuredLog } from './structured-logger';
+
+describe('writeStructuredLog', () => {
+  const logger: Pick<LoggerService, 'log' | 'warn' | 'error'> = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('writes JSON logs with required default fields', () => {
+    writeStructuredLog(logger, 'log', {
+      service: 'platform-api',
+      event: 'api.bootstrap.listen'
+    });
+
+    expect(logger.log).toHaveBeenCalledTimes(1);
+    const rawPayload = (logger.log as jest.Mock).mock.calls[0][0] as string;
+    const payload = JSON.parse(rawPayload) as Record<string, unknown>;
+
+    expect(payload.service).toBe('platform-api');
+    expect(payload.event).toBe('api.bootstrap.listen');
+    expect(payload.level).toBe('log');
+    expect(payload.tenantId).toBeNull();
+    expect(payload.jobId).toBeNull();
+    expect(payload.correlationId).toBeNull();
+    expect(payload.error).toBeNull();
+    expect(payload.metadata).toEqual({});
+    expect(typeof payload.timestamp).toBe('string');
+  });
+
+  it('writes warn logs preserving contextual identifiers', () => {
+    writeStructuredLog(logger, 'warn', {
+      service: 'platform-worker',
+      event: 'worker.job.skipped',
+      tenantId: 'tenant-a',
+      jobId: 'job-1',
+      correlationId: 'corr-1',
+      metadata: {
+        reason: 'duplicate'
+      }
+    });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const rawPayload = (logger.warn as jest.Mock).mock.calls[0][0] as string;
+    const payload = JSON.parse(rawPayload) as Record<string, unknown>;
+
+    expect(payload.tenantId).toBe('tenant-a');
+    expect(payload.jobId).toBe('job-1');
+    expect(payload.correlationId).toBe('corr-1');
+    expect(payload.metadata).toEqual({ reason: 'duplicate' });
+  });
+
+  it('normalizes Error instances on error logs', () => {
+    writeStructuredLog(logger, 'error', {
+      service: 'platform-worker',
+      event: 'worker.rabbitmq.topology.failed',
+      error: new Error('RabbitMQ unavailable')
+    });
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const rawPayload = (logger.error as jest.Mock).mock.calls[0][0] as string;
+    const payload = JSON.parse(rawPayload) as Record<string, unknown>;
+    const error = payload.error as Record<string, unknown>;
+
+    expect(error.name).toBe('Error');
+    expect(error.message).toBe('RabbitMQ unavailable');
+    expect(typeof error.stack).toBe('string');
+  });
+});

--- a/services/shared/observability/structured-logger.ts
+++ b/services/shared/observability/structured-logger.ts
@@ -25,7 +25,7 @@ interface StructuredLogRecord {
 }
 
 function normalizeError(error: unknown): unknown {
-  if (!error) {
+  if (error === null || error === undefined) {
     return null;
   }
 

--- a/services/shared/observability/structured-logger.ts
+++ b/services/shared/observability/structured-logger.ts
@@ -1,0 +1,78 @@
+import type { LoggerService } from '@nestjs/common';
+
+export type StructuredLogLevel = 'log' | 'warn' | 'error';
+
+export interface StructuredLogInput {
+  service: string;
+  event: string;
+  tenantId?: string | null;
+  jobId?: string | null;
+  correlationId?: string | null;
+  error?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+interface StructuredLogRecord {
+  timestamp: string;
+  level: StructuredLogLevel;
+  service: string;
+  event: string;
+  tenantId: string | null;
+  jobId: string | null;
+  correlationId: string | null;
+  error: unknown;
+  metadata: Record<string, unknown>;
+}
+
+function normalizeError(error: unknown): unknown {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack ?? null
+    };
+  }
+
+  return error;
+}
+
+function createStructuredRecord(
+  level: StructuredLogLevel,
+  input: StructuredLogInput
+): StructuredLogRecord {
+  return {
+    timestamp: new Date().toISOString(),
+    level,
+    service: input.service,
+    event: input.event,
+    tenantId: input.tenantId ?? null,
+    jobId: input.jobId ?? null,
+    correlationId: input.correlationId ?? null,
+    error: normalizeError(input.error),
+    metadata: input.metadata ?? {}
+  };
+}
+
+export function writeStructuredLog(
+  logger: Pick<LoggerService, 'log' | 'warn' | 'error'>,
+  level: StructuredLogLevel,
+  input: StructuredLogInput
+): void {
+  const payload = JSON.stringify(createStructuredRecord(level, input));
+
+  if (level === 'error') {
+    logger.error(payload);
+    return;
+  }
+
+  if (level === 'warn') {
+    logger.warn(payload);
+    return;
+  }
+
+  logger.log(payload);
+}

--- a/services/worker/src/infrastructure/messaging/rabbitmq-topology.service.ts
+++ b/services/worker/src/infrastructure/messaging/rabbitmq-topology.service.ts
@@ -3,6 +3,7 @@ import type { Channel, ChannelModel } from 'amqplib';
 import { connect } from 'amqplib';
 
 import { declareRabbitMqTopology } from '../../../../shared/contracts/rabbitmq-topology.contract';
+import { writeStructuredLog } from '../../../../shared/observability/structured-logger';
 import { RABBITMQ_TOPOLOGY } from './rabbitmq.constants';
 
 @Injectable()
@@ -12,14 +13,35 @@ export class RabbitMqTopologyService implements OnModuleInit, OnModuleDestroy {
   private channel: Channel | null = null;
 
   async onModuleInit(): Promise<void> {
-    const connection = await connect(RABBITMQ_TOPOLOGY.url);
-    const channel = await connection.createChannel();
-    this.connection = connection;
-    this.channel = channel;
+    try {
+      const connection = await connect(RABBITMQ_TOPOLOGY.url);
+      const channel = await connection.createChannel();
+      this.connection = connection;
+      this.channel = channel;
 
-    await declareRabbitMqTopology(channel, RABBITMQ_TOPOLOGY);
+      await declareRabbitMqTopology(channel, RABBITMQ_TOPOLOGY);
 
-    this.logger.log('RabbitMQ topology configured (queue + DLQ)');
+      writeStructuredLog(this.logger, 'log', {
+        service: 'platform-worker',
+        event: 'worker.rabbitmq.topology.configured',
+        metadata: {
+          exchange: RABBITMQ_TOPOLOGY.exchange,
+          queue: RABBITMQ_TOPOLOGY.queue,
+          deadLetterQueue: RABBITMQ_TOPOLOGY.deadLetterQueue
+        }
+      });
+    } catch (error) {
+      writeStructuredLog(this.logger, 'error', {
+        service: 'platform-worker',
+        event: 'worker.rabbitmq.topology.failed',
+        error,
+        metadata: {
+          exchange: RABBITMQ_TOPOLOGY.exchange,
+          queue: RABBITMQ_TOPOLOGY.queue
+        }
+      });
+      throw error;
+    }
   }
 
   async onModuleDestroy(): Promise<void> {

--- a/services/worker/src/main.ts
+++ b/services/worker/src/main.ts
@@ -4,10 +4,12 @@ import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
 import { startOpenTelemetry } from '../../shared/observability/open-telemetry';
+import { writeStructuredLog } from '../../shared/observability/structured-logger';
 import { createWorkerRmqOptions } from './infrastructure/messaging/rabbitmq-options.factory';
 import { WorkerModule } from './worker.module';
 
 async function bootstrap(): Promise<void> {
+  const logger = new Logger('Worker');
   const telemetry = startOpenTelemetry({
     serviceName: 'platform-worker',
     defaultMetricsPort: 9465
@@ -15,11 +17,17 @@ async function bootstrap(): Promise<void> {
 
   const app = await NestFactory.createMicroservice(WorkerModule, createWorkerRmqOptions());
   await app.listen();
-  Logger.log('Worker connected to RabbitMQ', 'Worker');
+  writeStructuredLog(logger, 'log', {
+    service: 'platform-worker',
+    event: 'worker.bootstrap.listen'
+  });
 
   const shutdownTelemetry = async (): Promise<void> => {
     await telemetry.shutdown();
-    Logger.log('OpenTelemetry SDK stopped', 'Worker');
+    writeStructuredLog(logger, 'log', {
+      service: 'platform-worker',
+      event: 'worker.telemetry.shutdown'
+    });
   };
 
   process.once('SIGINT', () => {
@@ -30,4 +38,12 @@ async function bootstrap(): Promise<void> {
   });
 }
 
-void bootstrap();
+void bootstrap().catch(error => {
+  const logger = new Logger('Worker');
+  writeStructuredLog(logger, 'error', {
+    service: 'platform-worker',
+    event: 'worker.bootstrap.error',
+    error
+  });
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #8

## 📌 Contexto
Padroniza logging estruturado em JSON para API e Worker, removendo mensagens string soltas e garantindo campos mínimos para correlação operacional.

## ✅ O que foi feito
- criado utilitário compartilhado `writeStructuredLog` em `services/shared/observability/structured-logger.ts`
- campos mínimos em todos os logs padronizados: `service`, `event`, `tenantId`, `jobId`, `correlationId`, `error`
- atualização dos bootstraps da API e Worker para log estruturado
- atualização do `RabbitMqTopologyService` para logs estruturados de sucesso/falha
- atualização do warning de indisponibilidade inicial no publisher RMQ da API para log estruturado
- removido `console.log` de bootstrap do worker
- adicionado teste unitário para o utilitário de logging estruturado

## 🧪 BDD
**Cenário:** Logs de bootstrap e infraestrutura seguem padrão JSON
**Dado** a inicialização da API e do Worker
**Quando** os eventos de bootstrap e configuração de topologia são emitidos
**Então** cada log contém `service`, `event`, `tenantId`, `jobId`, `correlationId`, `error`
**E** os campos ausentes são serializados como `null`
**E** erros são serializados em objeto estruturado

## 🔥 Tipo de Release
- [x] `minor` (melhoria de observabilidade sem quebra de contrato)

## Checklist
- [x] Testes adicionados/atualizados
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`
- [x] Sem alteração de contrato multi-tenant

## Evidências locais
- Typecheck: passou
- Build: passou
- Testes: 65/65 passou
- Coverage global: statements 84.94%, branches 80.32%, functions 80.59%, lines 84.39%
