### PR TITLE
chore: migrar tsconfig para compatibilidade TS6/TS7

### DIFF
--- a/services/api/test/rabbitmq-topology-alignment.spec.ts
+++ b/services/api/test/rabbitmq-topology-alignment.spec.ts
@@ -19,12 +19,13 @@ describe('RabbitMQ topology alignment between API and Worker', () => {
     };
     jest.resetModules();
 
-    const { RABBITMQ_TOPOLOGY } = await import(
+    // `node16` module resolution is stricter for dynamic `import()` paths in TS tests.
+    const { RABBITMQ_TOPOLOGY } = require(
       '../../worker/src/infrastructure/messaging/rabbitmq.constants'
-    );
-    const { RabbitMqBillingPublisher } = await import(
+    ) as typeof import('../../worker/src/infrastructure/messaging/rabbitmq.constants');
+    const { RabbitMqBillingPublisher } = require(
       '../src/modules/billing/infrastructure/messaging/rabbitmq-billing.publisher'
-    );
+    ) as typeof import('../src/modules/billing/infrastructure/messaging/rabbitmq-billing.publisher');
 
     const publisher = new RabbitMqBillingPublisher() as unknown as {
       topology: typeof RABBITMQ_TOPOLOGY;

--- a/services/api/tsconfig.build.json
+++ b/services/api/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../../dist",
+    "types": ["node"],
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts", "../shared/**/*.ts"],
+  "exclude": [
+    "test/**/*.ts",
+    "**/*.spec.ts",
+    "../shared/**/*.spec.ts",
+    "../../node_modules",
+    "../../dist"
+  ]
+}

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../../dist",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../shared/**/*.ts"],
+  "exclude": ["../../node_modules", "../../dist"]
+}

--- a/services/worker/test/rabbitmq-options.factory.spec.ts
+++ b/services/worker/test/rabbitmq-options.factory.spec.ts
@@ -38,9 +38,9 @@ describe('createWorkerRmqOptions', () => {
     };
     jest.resetModules();
 
-    const { createWorkerRmqOptions: createCustomWorkerRmqOptions } = await import(
+    const { createWorkerRmqOptions: createCustomWorkerRmqOptions } = require(
       '../src/infrastructure/messaging/rabbitmq-options.factory'
-    );
+    ) as typeof import('../src/infrastructure/messaging/rabbitmq-options.factory');
 
     const options = createCustomWorkerRmqOptions();
     expect(options.options?.queueOptions).toEqual(

--- a/services/worker/tsconfig.build.json
+++ b/services/worker/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../../dist",
+    "types": ["node"],
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts", "../shared/**/*.ts"],
+  "exclude": [
+    "test/**/*.ts",
+    "**/*.spec.ts",
+    "../shared/**/*.spec.ts",
+    "../../node_modules",
+    "../../dist"
+  ]
+}

--- a/services/worker/tsconfig.json
+++ b/services/worker/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../../dist",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../shared/**/*.ts"],
+  "exclude": ["../../node_modules", "../../dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "moduleResolution": "node16",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES2020",
-    "lib": ["ES2020"],
-    "moduleResolution": "node",
     "rootDir": ".",
     "outDir": "dist",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "types": ["node", "jest"]
   },
   "include": ["services/**/*.ts"],


### PR DESCRIPTION
Closes #11

## 📌 Contexto
Migração de configuração TypeScript para compatibilidade com TS6/TS7, removendo opções legadas e adicionando builds por serviço com `rootDir` explícito.

## ✅ O que foi feito
- criado `tsconfig.base.json` com opções compartilhadas suportadas
- migrado `moduleResolution` para `node16` e `module` para `Node16`
- atualizado `tsconfig.json` raiz para estender a base
- adicionados:
  - `services/api/tsconfig.json`
  - `services/api/tsconfig.build.json`
  - `services/worker/tsconfig.json`
  - `services/worker/tsconfig.build.json`
- definido `rootDir` explícito nos builds de API/Worker
- ajustados 2 testes que usavam `import()` dinâmico para `require()` para compatibilidade no modo `node16`

## 🧪 BDD
**Cenário:** Compilação compatível com TS5.x e TS6-next sem deprecações bloqueantes
**Dado** os tsconfigs raiz e por serviço
**Quando** executamos `tsc -p` na raiz, API e Worker com TS5.x e `typescript@next`
**Então** a compilação passa
**E** não há erro de deprecação de `moduleResolution=node10`
**E** os builds por serviço possuem `rootDir` explícito

## 🔥 Tipo de Release
- [x] `patch` (ajuste técnico sem mudança funcional de contrato)

## Checklist
- [x] Testes adicionados/atualizados
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`
- [x] `npx -p typescript@next tsc -p tsconfig.json --noEmit`
- [x] `npx -p typescript@next tsc -p services/api/tsconfig.build.json`
- [x] `npx -p typescript@next tsc -p services/worker/tsconfig.build.json`
- [x] Sem impacto no contrato multi-tenant

## Evidências locais
- TS5 raiz: `npm run typecheck` e `npm run build` passaram
- TS5 por serviço: `npx tsc -p services/api/tsconfig.build.json` e `npx tsc -p services/worker/tsconfig.build.json` passaram
- TS next: root/API/Worker passaram
- Testes: 66/66 passou
- Coverage global: statements 84.94%, branches 80.64%, functions 80.59%, lines 84.39%
