### PR TITLE
fix: segregar tsconfig de app/build e testes por serviço

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "description": "Base multi-tenant platform with NestJS API and worker",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "npm run build:api && npm run build:worker",
+    "build:api": "tsc -p services/api/tsconfig.build.json",
+    "build:worker": "tsc -p services/worker/tsconfig.build.json",
+    "typecheck": "npm run typecheck:api && npm run typecheck:worker",
+    "typecheck:api": "tsc -p services/api/tsconfig.json --noEmit",
+    "typecheck:worker": "tsc -p services/worker/tsconfig.json --noEmit",
+    "typecheck:api:test": "tsc -p services/api/tsconfig.spec.json --noEmit",
+    "typecheck:worker:test": "tsc -p services/worker/tsconfig.spec.json --noEmit",
     "test": "jest --runInBand",
     "start:api": "ts-node services/api/src/main.ts",
     "start:worker": "ts-node services/worker/src/main.ts"

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -3,8 +3,14 @@
   "compilerOptions": {
     "rootDir": "..",
     "outDir": "../../dist",
-    "types": ["node", "jest"]
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "../shared/**/*.ts"],
-  "exclude": ["../../node_modules", "../../dist"]
+  "include": ["src/**/*.ts", "../shared/**/*.ts"],
+  "exclude": [
+    "test/**/*.ts",
+    "**/*.spec.ts",
+    "../shared/**/*.spec.ts",
+    "../../node_modules",
+    "../../dist"
+  ]
 }

--- a/services/api/tsconfig.spec.json
+++ b/services/api/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../../dist/services/api-spec",
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../shared/**/*.ts"],
+  "exclude": ["../../node_modules", "../../dist"]
+}

--- a/services/worker/tsconfig.json
+++ b/services/worker/tsconfig.json
@@ -3,8 +3,14 @@
   "compilerOptions": {
     "rootDir": "..",
     "outDir": "../../dist",
-    "types": ["node", "jest"]
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "../shared/**/*.ts"],
-  "exclude": ["../../node_modules", "../../dist"]
+  "include": ["src/**/*.ts", "../shared/**/*.ts"],
+  "exclude": [
+    "test/**/*.ts",
+    "**/*.spec.ts",
+    "../shared/**/*.spec.ts",
+    "../../node_modules",
+    "../../dist"
+  ]
 }

--- a/services/worker/tsconfig.spec.json
+++ b/services/worker/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../../dist/services/worker-spec",
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "../shared/**/*.ts"],
+  "exclude": ["../../node_modules", "../../dist"]
+}


### PR DESCRIPTION
Closes #12

## 🧪 BDD
- [x] Dado os tsconfigs de app/build por serviço, quando executar `tsc -p services/api/tsconfig.json --noEmit`, então não depende de tipos de teste e passa.
- [x] Dado os tsconfigs de app/build por serviço, quando executar `tsc -p services/worker/tsconfig.json --noEmit`, então não depende de tipos de teste e passa.
- [x] Dado os tsconfigs de testes por serviço, quando executar `tsc -p services/api/tsconfig.spec.json --noEmit` e `tsc -p services/worker/tsconfig.spec.json --noEmit`, então os tipos de Jest/Node são resolvidos.
- [x] Dado a suíte de testes, quando executar `npm test` e `npm test -- --coverage`, então permanece verde.

## 🔥 Tipo de Release
- [x] Patch (correção sem breaking change)

## ✅ Checklist
- [x] Critérios de aceite da issue atendidos
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`
- [x] Sem regressão de arquitetura/multi-tenant

## Mudanças
- Ajusta `services/api/tsconfig.json` e `services/worker/tsconfig.json` para excluir specs/testes e remover dependência de tipos Jest nos tsconfigs de app.
- Mantém `tsconfig.build.json` por serviço desacoplado de testes.
- Cria `tsconfig.spec.json` por serviço com `types: ["jest", "node"]`.
- Atualiza scripts no `package.json` para build/typecheck por serviço e adiciona typecheck explícito para testes.
