### PR TITLE
refactor: consolidar drift de scaffolding manual e caminhos legados

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
 
       - run: npm install
+      - run: npm run validate:drift
       - run: npm run lint || echo "No lint script"
       - run: npm run typecheck || echo "No typecheck script"
       - run: npm run test -- --coverage || echo "No test script"

--- a/docs/architecture/adr-0013-scaffolding-drift-consolidation.md
+++ b/docs/architecture/adr-0013-scaffolding-drift-consolidation.md
@@ -1,0 +1,27 @@
+# ADR-0013: Consolidar Drift de Scaffolding Manual e Caminhos Legados
+
+- Status: Aceito
+- Data: 2026-03-02
+- Issue: #13
+
+## Contexto
+
+Foi identificado drift local manual em dois blocos:
+1. Configuração de agentes Codex.
+2. Estruturas legadas de código fora do fluxo principal de API/Worker.
+
+## Decisões
+
+| Grupo | Decisão | Justificativa |
+| --- | --- | --- |
+| `.codex/config.toml`, `.codex/manager.toml`, `.codex/platform-architect.toml`, `.codex/worker.toml`, `.codex/qa.toml`, `.codex/issue-generator.toml` | **Manter** | Representam a configuração canônica atual dos agentes. |
+| `.codex/agents/*.toml` | **Remover** | Estrutura duplicada/legada, substituída por `.codex/*.toml`. |
+| `services/worker/src/app.module.ts`, `services/worker/src/modules/**`, `services/worker/src/shared/**`, `services/api/src/shared/**` | **Remover** | Caminhos legados fora da arquitetura vigente (`worker.module.ts`, `application/domain/infrastructure/interfaces`, `services/shared`). |
+| `services/api/package.json`, `services/worker/package.json` | **Remover** | O monorepo usa `package.json` raiz como fonte única de scripts e dependências. |
+| `services/*/tsconfig.json`, `services/*/tsconfig.build.json`, `services/*/tsconfig.spec.json` | **Manter** | Estrutura vigente por serviço para separar app/build e testes com tipagem explícita. |
+
+## Consequências
+
+- Qualquer reintrodução de caminhos legados passa a ser tratada como regressão.
+- A validação de drift é automatizada no CI para impedir duplicidade de configuração e scaffolding fora do padrão.
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Base multi-tenant platform with NestJS API and worker",
   "scripts": {
+    "validate:drift": "bash scripts/validate-scaffolding-drift.sh",
     "build": "npm run build:api && npm run build:worker",
     "build:api": "tsc -p services/api/tsconfig.build.json",
     "build:worker": "tsc -p services/worker/tsconfig.build.json",

--- a/scripts/validate-scaffolding-drift.sh
+++ b/scripts/validate-scaffolding-drift.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+required_codex_files=(
+  ".codex/config.toml"
+  ".codex/manager.toml"
+  ".codex/platform-architect.toml"
+  ".codex/worker.toml"
+  ".codex/qa.toml"
+  ".codex/issue-generator.toml"
+)
+
+for file in "${required_codex_files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing required Codex config: $file"
+    exit 1
+  fi
+done
+
+if [[ -d ".codex/agents" ]]; then
+  echo "Legacy Codex path must not exist: .codex/agents"
+  exit 1
+fi
+
+forbidden_paths=(
+  "services/worker/src/app.module.ts"
+  "services/worker/src/modules"
+  "services/worker/src/shared"
+  "services/api/src/shared"
+  "services/api/package.json"
+  "services/worker/package.json"
+)
+
+for path in "${forbidden_paths[@]}"; do
+  if [[ -e "$path" ]]; then
+    echo "Forbidden legacy path detected: $path"
+    exit 1
+  fi
+done
+
+required_service_tsconfigs=(
+  "services/api/tsconfig.json"
+  "services/api/tsconfig.build.json"
+  "services/api/tsconfig.spec.json"
+  "services/worker/tsconfig.json"
+  "services/worker/tsconfig.build.json"
+  "services/worker/tsconfig.spec.json"
+)
+
+for file in "${required_service_tsconfigs[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing required service tsconfig: $file"
+    exit 1
+  fi
+done
+
+echo "Scaffolding drift validation passed."

--- a/services/worker/test/scaffolding-drift-consolidation.spec.ts
+++ b/services/worker/test/scaffolding-drift-consolidation.spec.ts
@@ -1,0 +1,52 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Scaffolding drift consolidation guard', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+  const requiredCodexFiles = [
+    '.codex/config.toml',
+    '.codex/manager.toml',
+    '.codex/platform-architect.toml',
+    '.codex/worker.toml',
+    '.codex/qa.toml',
+    '.codex/issue-generator.toml'
+  ];
+
+  const forbiddenLegacyPaths = [
+    '.codex/agents',
+    'services/worker/src/app.module.ts',
+    'services/worker/src/modules',
+    'services/worker/src/shared',
+    'services/api/src/shared',
+    'services/api/package.json',
+    'services/worker/package.json'
+  ];
+
+  const requiredServiceTsConfigs = [
+    'services/api/tsconfig.json',
+    'services/api/tsconfig.build.json',
+    'services/api/tsconfig.spec.json',
+    'services/worker/tsconfig.json',
+    'services/worker/tsconfig.build.json',
+    'services/worker/tsconfig.spec.json'
+  ];
+
+  it('keeps only canonical Codex config file locations', () => {
+    for (const relativePath of requiredCodexFiles) {
+      expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+    }
+  });
+
+  it('does not reintroduce forbidden legacy paths', () => {
+    for (const relativePath of forbiddenLegacyPaths) {
+      expect(existsSync(path.join(repoRoot, relativePath))).toBe(false);
+    }
+  });
+
+  it('keeps tsconfig segmentation by service', () => {
+    for (const relativePath of requiredServiceTsConfigs) {
+      expect(existsSync(path.join(repoRoot, relativePath))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #13

## 🧪 BDD
- [x] Dado a consolidação dos arquivos manuais, quando validar os grupos definidos na issue #13, então cada grupo possui decisão explícita de manter/migrar/remover registrada em ADR.
- [x] Dado o repositório, quando executar `npm run validate:drift`, então caminhos legados e duplicidades de `.codex/agents` são bloqueados automaticamente.
- [x] Dado a suíte de testes, quando executar `npm test`, então a proteção contra regressão de drift permanece verde.
- [x] Dado o pipeline CI, quando uma PR rodar, então a validação de drift é executada antes de typecheck/testes.

## 🔥 Tipo de Release
- [x] Minor (refactor de processo/arquitetura sem breaking change)

## ✅ Checklist
- [x] Critérios de aceite atendidos
- [x] `npm run validate:drift`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`
- [x] Sem regressão de multi-tenant/arquitetura

## Mudanças
- Adiciona ADR com decisão explícita por grupo de arquivos: `docs/architecture/adr-0013-scaffolding-drift-consolidation.md`.
- Adiciona script `scripts/validate-scaffolding-drift.sh` para bloquear reintrodução de caminhos legados e garantir arquivos canônicos de `.codex` e `tsconfig` por serviço.
- Integra `validate:drift` no `package.json` e no workflow de CI (`.github/workflows/ci.yml`).
- Adiciona teste de guarda `services/worker/test/scaffolding-drift-consolidation.spec.ts` para cobrir a consolidação no ciclo de testes.
