### PR TITLE
chore: endurecer gates de CI removendo fallbacks permissivos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: npm install
       - run: npm run validate:drift
       - run: npm run lint
-      - run: npm run typecheck || echo "No typecheck script"
-      - run: npm run test -- --coverage || echo "No test script"
+      - run: npm run typecheck
+      - run: npm run test -- --coverage


### PR DESCRIPTION
Closes #25

## 🧪 BDD
- [x] Dado o workflow de CI, quando executar o job `build-test`, então os passos críticos (`lint`, `typecheck`, `test --coverage`) não usam fallback permissivo com `|| echo`.
- [x] Dado a aplicação no estado atual, quando executar localmente `npm run validate:drift`, `npm run lint`, `npm run typecheck`, `npm run build` e `npm test -- --coverage`, então tudo passa.
- [x] Dado um cenário de erro no typecheck, quando forçado localmente, então o comando falha com código não-zero (sem mascaramento).

## 🔥 Tipo de Release
- [x] Patch (endurecimento de gate de CI sem breaking change funcional)

## ✅ Checklist
- [x] Critérios de aceite atendidos
- [x] `npm run validate:drift`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`

## Mudanças
- Remove `|| echo` de `typecheck` e `test --coverage` no workflow CI.
- Mantém o pipeline com gates críticos obrigatórios e falha real quando houver erro.
