### PR TITLE
chore: elevar threshold global de cobertura

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,10 +9,11 @@ const config: Config = {
   collectCoverageFrom: ['services/**/*.ts', '!services/**/main.ts'],
   coverageThreshold: {
     global: {
-      branches: 35,
-      functions: 45,
-      lines: 45,
-      statements: 45
+      // Fase 1 de endurecimento do baseline global.
+      branches: 70,
+      functions: 70,
+      lines: 75,
+      statements: 75
     },
     './services/worker/src/interfaces/messages/job.consumer.ts': {
       branches: 100,


### PR DESCRIPTION
Closes #26

## 🧪 BDD
- [x] Dado o baseline de cobertura atual da suíte (~84% statements/~80% branches), quando ajustar o threshold global, então os novos limites ficam mais rígidos sem quebrar o pipeline.
- [x] Dado o `jest.config.ts`, quando rodar `npm test -- --coverage`, então o gate global passa a exigir no mínimo: branches 70, functions 70, lines 75, statements 75.
- [x] Dado o endurecimento gradual, quando validar a aplicação, então `validate:drift`, `lint`, `typecheck`, `build`, `test` e `test -- --coverage` permanecem verdes.

## 🔥 Tipo de Release
- [x] Patch (melhoria de quality gate sem breaking change funcional)

## ✅ Checklist
- [x] Critérios de aceite atendidos
- [x] `npm run validate:drift`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- --coverage`

## Mudanças
- Eleva `coverageThreshold.global` em `jest.config.ts` de `35/45/45/45` para `70/70/75/75` (branches/functions/lines/statements).
- Registra no arquivo que o ajuste é fase 1 de endurecimento gradual.
